### PR TITLE
Arregla el juego para iOS

### DIFF
--- a/www/js/juego.js
+++ b/www/js/juego.js
@@ -113,7 +113,7 @@ var app={
 };
 
 if ('addEventListener' in document) {
-    document.addEventListener('DOMContentLoaded', function() {
+    document.addEventListener('deviceready', function() {
         app.inicio();
     }, false);
 }


### PR DESCRIPTION
Cambia DOMContentLoaded por deviceready para no usar el plugin de acelerómetro antes de que esté disponible.

Fix #1 